### PR TITLE
Fix MELPA Stable dependencies on unreleased packages (#7)

### DIFF
--- a/verilog-ext.el
+++ b/verilog-ext.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/gmlarumbe/verilog-ext
 ;; Version: 0.2.0
 ;; Keywords: Verilog, IDE, Tools
-;; Package-Requires: ((emacs "29.1") (verilog-mode "2023.6.6.141322628") (verilog-ts-mode "0.0.0") (eglot "1.9") (lsp-mode "8.0.1") (ag "0.48") (ripgrep "0.4.0") (hydra "0.15.0") (apheleia "3.1") (yasnippet "0.14.0") (company "0.9.13") (flycheck "33-cvs") (outshine "3.1-pre") (async "1.9.7"))
+;; Package-Requires: ((emacs "29.1") (verilog-mode "2023.6.6.141322628") (verilog-ts-mode "0.0.0") (eglot "1.9") (lsp-mode "8.0.0") (ag "0.48") (ripgrep "0.4.0") (hydra "0.15.0") (apheleia "3.1") (yasnippet "0.14.0") (company "0.9.13") (flycheck "32") (outshine "3.0.1") (async "1.9.7"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Fix `Package-Requires` header entry so that all the dependencies are available on MELPA Stable for future releases.

This will have no effect if using MELPA as these version numbers refer to the minimum acceptable version and not to the actual downloaded version (except for MELPA Stable). MELPA packages are built directly from the latest package source code in the upstream repositories.

Use of MELPA Stable will be supported and tested for `verilog-ext` but not recommended as some of the released versions of the dependencies are a bit old (e.g. `outshine 3.0.1` dates from Jan 2019). On top of that, according to https://github.com/melpa/melpa#melpa-stable:

> Note that the MELPA maintainers do not use MELPA Stable themselves, and do not particularly recommend its use.