### PR TITLE
Remove support from company-keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ This package provides some extensions on top of the great Emacs [verilog-mode](h
 * [Highlight and align typedefs](#typedefs)
 * [Auto-configure `time-stamp`](#time-stamp)
 * [Auto-convert block end comments to names](#block-end-comments)
-* [Auto-configure `company-keywords`](#company-keywords)
 * [Port connection utilities](#port-connections)
 
 ## Installation ##
@@ -74,7 +73,6 @@ By default all features are enabled:
         typedefs
         time-stamp
         block-end-comments
-        company-keywords
         ports))
 (verilog-ext-mode-setup)
 (add-hook 'verilog-mode-hook #'verilog-ext-mode)
@@ -112,7 +110,6 @@ If installed and loaded via `use-package`:
           typedefs
           time-stamp
           block-end-comments
-          company-keywords
           ports))
   :config
   (verilog-ext-mode-setup))
@@ -396,11 +393,6 @@ For configuration see [wiki](https://github.com/gmlarumbe/verilog-ext/wiki/Time-
 Auto convert block comments to names after file saving.
 
    - `verilog-ext-block-end-comments-to-names-mode`
-
-## Company keywords ##
-
-
-Setup `company` to complete with SystemVerilog keywords.
 
 
 ## Port connections ##

--- a/verilog-ext-utils.el
+++ b/verilog-ext-utils.el
@@ -28,7 +28,6 @@
 (require 'xref)
 (require 'ag)
 (require 'ripgrep)
-(require 'company-keywords)
 
 ;;;; Custom
 (defcustom verilog-ext-file-extension-re "\\.s?vh?\\'"
@@ -664,11 +663,6 @@ If on a `verilog-ts-mode' buffer, run `indent-for-tab-command' with ARG."
         (t
          (error "Wrong major-mode to run `verilog-ext-tab'"))))
 
-;;;; Misc
-(defun verilog-ext-company-keywords-add ()
-  "Add `verilog-keywords' to `company-keywords' backend."
-  (dolist (mode '(verilog-mode verilog-ts-mode))
-    (add-to-list 'company-keywords-alist `(,mode ,@verilog-keywords))))
 
 (provide 'verilog-ext-utils)
 

--- a/verilog-ext.el
+++ b/verilog-ext.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/gmlarumbe/verilog-ext
 ;; Version: 0.2.0
 ;; Keywords: Verilog, IDE, Tools
-;; Package-Requires: ((emacs "29.1") (verilog-mode "2023.6.6.141322628") (verilog-ts-mode "0.0.0") (eglot "1.9") (lsp-mode "8.0.0") (ag "0.48") (ripgrep "0.4.0") (hydra "0.15.0") (apheleia "3.1") (yasnippet "0.14.0") (company "0.9.13") (flycheck "32") (outshine "3.0.1") (async "1.9.7"))
+;; Package-Requires: ((emacs "29.1") (verilog-mode "2023.6.6.141322628") (verilog-ts-mode "0.0.0") (eglot "1.9") (lsp-mode "8.0.0") (ag "0.48") (ripgrep "0.4.0") (hydra "0.15.0") (apheleia "3.1") (yasnippet "0.14.0") (flycheck "32") (outshine "3.0.1") (async "1.9.7"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -43,7 +43,6 @@
 ;;  - Workspace tags, typedef analysis and caching
 ;;  - Time-stamp auto-configuration
 ;;  - Convert block end comments to names
-;;  - Automatically add SystemVerilog keywords to `company-keywords` backend
 ;;  - Port connections utilities
 
 ;;; Code:
@@ -72,7 +71,6 @@
                                       typedefs
                                       time-stamp
                                       block-end-comments
-                                      company-keywords
                                       ports)
   "Which Verilog-ext features to enable."
   :type '(set (const :tag "Improved syntax highlighting via `font-lock'."
@@ -111,8 +109,6 @@
                 time-stamp)
               (const :tag "Convert block end comments to names (endmodule // top → endmodule : top)"
                 block-end-comments)
-              (const :tag "Add `verilog-keywords' to `company-keywords' backend."
-                company-keywords)
               (const :tag "Port connections utilities."
                 ports))
   :group 'verilog-ext)
@@ -210,8 +206,6 @@ FEATURES can be a single feature or a list of features."
     (verilog-ext-font-lock-setup))
   (verilog-ext-when-feature 'hideshow
     (verilog-ext-hs-setup))
-  (verilog-ext-when-feature 'company-keywords
-    (verilog-ext-company-keywords-add))
   (verilog-ext-when-feature 'template
     (verilog-ext-template-add-snippets))
   (verilog-ext-when-feature 'typedefs


### PR DESCRIPTION
`verilog-keywords` completions are now added by `verilog-ext-capf`.

This removes depending on `company-keywords` and `company` while allowing completion with other `completion-at-point` based packages.

In case someone is still interested in using `company-keywords`:
```elisp
(defun verilog-ext-company-keywords-add ()
  "Add `verilog-keywords' to `company-keywords' backend."
  (dolist (mode '(verilog-mode verilog-ts-mode))
    (add-to-list 'company-keywords-alist `(,mode ,@verilog-keywords))))
``` 