### PR TITLE
Hook hs-minor-mode into verilog-mode

### DIFF
--- a/verilog-ext-hs.el
+++ b/verilog-ext-hs.el
@@ -69,7 +69,8 @@
                                            ,verilog-ext-hs-block-start-keywords-re
                                            ,verilog-ext-hs-block-end-keywords-re
                                            nil
-                                           ,(cdr mode)))))
+                                           ,(cdr mode))))
+  (add-hook verilog-mode-hook hs-minor-mode))
 
 (defun verilog-ext-hs-toggle-hiding (&optional e)
   "Wrapper for `hs-toggle-hiding' depending on current Verilog `major-mode'.


### PR DESCRIPTION
Add hook to `verilog-mode` for `hs-minor-mode`.

`verilog-ts-mode` loads `verilog-mode` so it seemed sensible to hook into `verilog-mode`.

ERT tests are failing on what seems like the absence of a treesitter dependency, but they fail before and after the patch so it likely unrelated.