### PR TITLE
feat(langserver): add rules config search flag to Verible command

### DIFF
--- a/langserver/verible.json
+++ b/langserver/verible.json
@@ -3,7 +3,7 @@
   "languageId": "verilog",
   "command": [
     "verible-verilog-ls",
-    "--rules_config_earch"
+    "--rules_config_search"
   ],
   "settings": {}
 }


### PR DESCRIPTION
- Updated `langserver/verible.json` to include `--rules_config_search` in the Verible command configuration.
- Enables searching for rules configuration files during execution.