### PR TITLE
Add support for vide LSP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Auto-configure various SystemVerilog language servers for `lsp-bridge`, `lsp-mod
 
 - [hdl_checker](https://github.com/suoto/hdl_checker)
 - [svlangserver](https://github.com/imc-trading/svlangserver)
+- [vide](https://github.com/pascal-lab/vide)
 - [verible](https://github.com/chipsalliance/verible/tree/master/verilog/tools/ls)
 - [svls](https://github.com/dalance/svls)
 - [veridian](https://github.com/vivekmalneedi/veridian)

--- a/langserver/vide.json
+++ b/langserver/vide.json
@@ -1,0 +1,9 @@
+{
+  "name": "vide",
+  "languageId": "verilog",
+  "command": [
+    "vide"
+  ],
+
+  "settings": {}
+}

--- a/verilog-ext-eglot.el
+++ b/verilog-ext-eglot.el
@@ -23,6 +23,7 @@
 ;; Support for various SystemVerilog language servers
 ;;     - hdl_checker: https://github.com/suoto/hdl_checker
 ;;     - svlangserver: https://github.com/imc-trading/svlangserver
+;;     - vide: https://github.com/pascal-lab/vide
 ;;     - verible: https://github.com/chipsalliance/verible/tree/master/verilog/tools/ls
 ;;     - svls: https://github.com/dalance/svls
 ;;     - veridian: https://github.com/vivekmalneedi/veridian

--- a/verilog-ext-lsp-bridge.el
+++ b/verilog-ext-lsp-bridge.el
@@ -26,6 +26,7 @@
 ;;  - Additional:
 ;;     - hdl_checker: https://github.com/suoto/hdl_checker
 ;;     - svlangserver: https://github.com/imc-trading/svlangserver
+;;     - vide: https://github.com/pascal-lab/vide
 ;;     - svls: https://github.com/dalance/svls
 ;;     - veridian: https://github.com/vivekmalneedi/veridian
 
@@ -67,4 +68,3 @@ Override any previous configuration for `verilog-mode' and `verilog-ts-mode'."
 (provide 'verilog-ext-lsp-bridge)
 
 ;;; verilog-ext-lsp-bridge.el ends here
-

--- a/verilog-ext-lsp.el
+++ b/verilog-ext-lsp.el
@@ -25,6 +25,7 @@
 ;;     - hdl_checker: https://github.com/suoto/hdl_checker
 ;;     - svlangserver: https://github.com/imc-trading/svlangserver
 ;;  - Additional:
+;;     - vide: https://github.com/pascal-lab/vide
 ;;     - verible: https://github.com/chipsalliance/verible/tree/master/verilog/tools/ls
 ;;     - svls: https://github.com/dalance/svls
 ;;     - veridian: https://github.com/vivekmalneedi/veridian

--- a/verilog-ext-lspce.el
+++ b/verilog-ext-lspce.el
@@ -23,6 +23,7 @@
 ;; Support for various SystemVerilog language servers
 ;;     - hdl_checker: https://github.com/suoto/hdl_checker
 ;;     - svlangserver: https://github.com/imc-trading/svlangserver
+;;     - vide: https://github.com/pascal-lab/vide
 ;;     - verible: https://github.com/chipsalliance/verible/tree/master/verilog/tools/ls
 ;;     - svls: https://github.com/dalance/svls
 ;;     - veridian: https://github.com/vivekmalneedi/veridian
@@ -167,4 +168,3 @@ Override any previous configuration for `verilog-mode' and `verilog-ts-mode'."
 (provide 'verilog-ext-lspce)
 
 ;;; verilog-ext-lspce.el ends here
-

--- a/verilog-ext-utils.el
+++ b/verilog-ext-utils.el
@@ -133,6 +133,7 @@ type_t foo1, foo2 , foo4, foo6[], foo7 [25], foo8 ;")
 (defconst verilog-ext-lsp-available-servers
   '((ve-hdl-checker  ("hdl_checker" "--lsp")  "hdl-checker.json")
     (ve-svlangserver "svlangserver"           "svlangserver.json")
+    (ve-vide         "vide"                   "vide.json")
     (ve-verible-ls   "verible-verilog-ls"     "verible.json")
     (ve-svls         "svls"                   "svls.json")
     (ve-veridian     "veridian"               "veridian.json")


### PR DESCRIPTION
Vide (https://github.com/pascal-lab/vide) is an open-source modern Verilog/SystemVerilog language server and IDE from the PASCAL Research Group. Our homepage: https://vide.pascal-lab.net/en/

This PR adds `vide` support for `verilog-ext`.